### PR TITLE
Deprecate repo, point to Pagure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 cardsite
 ========
 
+## [Project moved to Pagure](https://pagure.io/cardsite)
+
+**Please file any issues or pull requests against the [Pagure project](https://pagure.io/cardsite)!**
+
+
 I just found semantic-ui, and it seems like it is super amazing. Rather than
 just downloading it, I’ve used this opportunity to brush up on how to use a
 javascript build chain.


### PR DESCRIPTION
As discussed earlier, this repository was migrated to Pagure to improve accessibility and visibility for other Fedora contributors. This project can be found [here](https://pagure.io/cardsite).

This PR adds a note to the README pointing to the new home for the project, along with instructions to file issues and pull requests against the Pagure repo.
